### PR TITLE
Move arguments and tidy examples

### DIFF
--- a/examples/Fe2O3/Fe2O3.py
+++ b/examples/Fe2O3/Fe2O3.py
@@ -1,28 +1,15 @@
-from pytaser import generator, plotter
+from pytaser.generator import TASGenerator
+from pytaser.plotter import TASPlotter
 
 api_key = None  # Use your API key here
-fe2o3_temp = 298
-fe2o3_conc = 10e21
+temp = 298
+conc = 10e21
 bandgap = 2.2  # based on https://aip.scitation.org/doi/full/10.1063/1.2177426
-# transitions_fe2o3 = [
-#     (8, 11, "down"),
-#     (9, 10, "up"),
-#     (4, 14, "up"),
-#     (6, 20, "down"),
-#     (6, 28, "up"),
-# ]
 
-# Fe2O3 is  spin-polarised, so we must define any relevant transitions we want to
-# see as spin-up or spin-down
-
-fe2o3_generator = generator.TASGenerator.from_mpid(
-    "mp-565814", fe2o3_temp, fe2o3_conc, bandgap, api_key=api_key
+generator = TASGenerator.from_mpid("mp-565814", bandgap, api_key=api_key)
+tas = generator.generate_tas(temp, conc)
+plotter = TASPlotter(
+    tas, bandgap_ev=bandgap, material_name="Fe2O3", temp=temp, conc=conc
 )
-fe2o3_tas = fe2o3_generator.generate_tas(energy_min=0.0, energy_max=10.0)
-fe2o3_plotter = plotter.TASPlotter(
-    fe2o3_tas, bandgap, material_name="Fe2O3", temp=fe2o3_temp, conc=fe2o3_conc
-)
-plot_fe2o3 = fe2o3_plotter.get_plot(
-    xaxis="wavelength", transition_cutoff=0.03, xmin=350, xmax=1400, yaxis="TAS (deltaT)"
-)
-plot_fe2o3.show()
+plt = plotter.get_plot(xaxis="wavelength", xmin=350, xmax=1400, yaxis="TAS (deltaT)")
+plt.show()

--- a/examples/GaAs/GaAs.py
+++ b/examples/GaAs/GaAs.py
@@ -1,18 +1,15 @@
-from pytaser import generator, plotter
+from pytaser.generator import TASGenerator
+from pytaser.plotter import TASPlotter
 
 api_key = None  # Use your API key here
-gaas_temp = 298
-gaas_conc = 10e21
+temp = 298
+conc = 10e21
 bandgap = 1.46
 
-GaAs_generator = generator.TASGenerator.from_mpid(
-    "mp-2534", gaas_temp, gaas_conc, bandgap, api_key=api_key
+generator = TASGenerator.from_mpid("mp-2534", bandgap, api_key=api_key)
+tas = generator.generate_tas(temp, conc)
+plotter = TASPlotter(
+    tas, bandgap_ev=bandgap, material_name="GaAs", temp=temp, conc=conc
 )
-GaAs_tas = GaAs_generator.generate_tas(energy_min=0.0, energy_max=10.0)
-GaAs_plotter = plotter.TASPlotter(
-    GaAs_tas, bandgap, material_name="GaAs", temp=gaas_temp, conc=gaas_conc
-)
-plot_gaas = GaAs_plotter.get_plot(
-    xaxis="wavelength", transition_cutoff=0.03, xmin=350, xmax=1000, yaxis="TAS (deltaT)"
-)
-plot_gaas.show()
+plt = plotter.get_plot(xaxis="wavelength", xmin=350, xmax=1000, yaxis="TAS (deltaT)")
+plt.show()

--- a/examples/TiO2_anatase/TiO2_anatase.py
+++ b/examples/TiO2_anatase/TiO2_anatase.py
@@ -1,18 +1,15 @@
-from pytaser import generator, plotter
+from pytaser.generator import TASGenerator
+from pytaser.plotter import TASPlotter
 
 api_key = None  # Use your API key here
-tio2a_temp = 298
-tio2a_conc = 10e21
+temp = 298
+conc = 10e21
 bandgap = 3.1
 
-tio2a_generator = generator.TASGenerator.from_mpid(
-    "mp-390", tio2a_temp, tio2a_conc, bandgap, api_key=api_key
+generator = TASGenerator.from_mpid("mp-390", bandgap, api_key=api_key)
+tas = generator.generate_tas(temp, conc)
+plotter = TASPlotter(
+    tas, bandgap_ev=bandgap, material_name="TiO2 (anatase)", temp=temp, conc=conc
 )
-tio2a_tas = tio2a_generator.generate_tas(energy_min=0.0, energy_max=10.0)
-tio2a_plotter = plotter.TASPlotter(
-    tio2a_tas, bandgap, material_name="TiO2 (anatase)", temp=tio2a_temp, conc=tio2a_conc
-)
-plot_tio2a = tio2a_plotter.get_plot(
-    xaxis="wavelength", transition_cutoff=0.03, xmin=350, xmax=1400, yaxis="TAS (deltaT)"
-)
-plot_tio2a.show()
+plt = plotter.get_plot(xaxis="wavelength", xmin=350, xmax=1400, yaxis="TAS (deltaT)")
+plt.show()

--- a/examples/TiO2_rutile/TiO2_rutile.py
+++ b/examples/TiO2_rutile/TiO2_rutile.py
@@ -1,19 +1,15 @@
-from pytaser import generator, plotter
+from pytaser.generator import TASGenerator
+from pytaser.plotter import TASPlotter
 
 api_key = None  # Use your API key here
-tio2r_temp = 298
-tio2r_conc = 10e21
+temp = 298
+conc = 10e21
 bandgap = 3.1
-# transitions_tio2r = [(8, 11), (9, 10), (4, 14), (6, 20), (6, 28)]
 
-tio2r_generator = generator.TASGenerator.from_mpid(
-    "mp-2657", tio2r_temp, tio2r_conc, bandgap, api_key=api_key
+generator = TASGenerator.from_mpid("mp-2657", bandgap, api_key=api_key)
+tas = generator.generate_tas(temp, conc)
+plotter = TASPlotter(
+    tas, bandgap_ev=bandgap, material_name="TiO2 (rutile)", temp=temp, conc=conc
 )
-tio2r_tas = tio2r_generator.generate_tas(energy_min=0.0, energy_max=10.0)
-tio2r_plotter = plotter.TASPlotter(
-    tio2r_tas, bandgap, material_name="TiO2 (rutile)", temp=tio2r_temp, conc=tio2r_conc
-)
-plot_tio2r = tio2r_plotter.get_plot(
-    xaxis="wavelength", transition_cutoff=0.03, xmin=350, xmax=1400, yaxis="TAS (deltaT)"
-)
-plot_tio2r.show()
+plt = plotter.get_plot(xaxis="wavelength", xmin=350, xmax=1400, yaxis="TAS (deltaT)")
+plt.show()

--- a/pytaser/plotter.py
+++ b/pytaser/plotter.py
@@ -46,15 +46,15 @@ class TASPlotter:
         self.energy_mesh_lambda = ev_to_lambda(self.energy_mesh_ev)
 
     def get_plot(
-            self,
-            relevant_transitions="auto",
-            xaxis="wavelength",
-            transition_cutoff=0.03,
-            xmin=None,
-            xmax=None,
-            ymin=None,
-            ymax=None,
-            yaxis="TAS (deltaT)",
+        self,
+        relevant_transitions="auto",
+        xaxis="wavelength",
+        transition_cutoff=0.03,
+        xmin=None,
+        xmax=None,
+        ymin=None,
+        ymax=None,
+        yaxis="TAS (deltaT)",
     ):
         """
         Args:


### PR DESCRIPTION
- Move `concs` and `temps` arguments from the generator constructor to the `generate_tas` function.
- Add sensible defaults for `energy_min` and `energy_max` in  `generate_tas`.
- Reduce energy step to make the plots smoother.
- Reduce code in examples (e.g., don't specify arguments if they are the defaults). I also changed the limits in generate_tas as a lot of the energy range generated was not used in the plotting (e.g., 350 nm is 3.5 eV but previously we were generating up to 10 eV).