### PR TITLE
Pymatgen update

### DIFF
--- a/pytaser/generator.py
+++ b/pytaser/generator.py
@@ -222,16 +222,12 @@ def occ_dependent_alpha(dfc, occs, spin=Spin.up, sigma=None, cshift=None):
             em_matrix_el = em_occ_factor * matrix_el_wout_occ_factor
             both_matrix_el = both_occ_factor * matrix_el_wout_occ_factor
 
-            if dfc.ismear == 0:  # error in pymatgen, TODO: PR!
-                ismear = -0.1
-            else:
-                ismear = dfc.ismear
             smeared_wout_matrix_el = optics.get_delta(
                 x0=decel,
                 sigma=sigma,
                 nx=dfc.nedos,
                 dx=dfc.deltae,
-                ismear=ismear,
+                ismear=dfc.ismear,
             )
 
             dielectric_dict["absorption"] += (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-pytest
-pytest-mpl
+pytest>=7.1.3
+pytest-mpl==0.15.1
 numpy
 monty
-pymatgen
-matplotlib
+pymatgen>=2023.05.31
+matplotlib>=3.7.1
 scipy
 setuptools
 deepdiff

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "numpy",
         "scipy",
         "matplotlib>=3.7.1",
-        "pymatgen>=2017.12.30",
+        "pymatgen>=2023.05.31",
         "setuptools"
     ],
     extras_require={


### PR DESCRIPTION
The new version of pymatgen has been released, which has the bug fix for the optics module, so this is adjusting to use the new fixed pymatgen and remove the workaround/TODO I added to that part of the code.

https://github.com/materialsproject/pymatgen/releases/tag/v2023.05.31