### PR TITLE
Changed np.arange to np.linspace for the generation of egrid inside o…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+v2.1.3
+~~~~~~
+- Change of np.arange to np.linspace to avoid e_grid arrays with sizes different from NEDOS. (see the warning on numpy.arange documentation)
+
 v2.1.2
 ~~~~~~
 - Remove broken links from docs

--- a/pytaser/generator.py
+++ b/pytaser/generator.py
@@ -291,7 +291,7 @@ def occ_dependent_alpha(
         sigma = dfc.sigma
     if cshift is None:
         cshift = dfc.cshift
-    egrid = np.arange(0, dfc.nedos * dfc.deltae, dfc.deltae)
+    egrid = np.linspace(0, dfc.nedos * dfc.deltae, dfc.nedos, endpoint=False)
     dielectric_dict = {
         key: np.zeros_like(egrid, dtype=np.complex128)
         for key in ["absorption", "emission", "both"]
@@ -667,9 +667,9 @@ class TASGenerator:
         jdos_light_total = np.zeros(len(energy_mesh_ev))
 
         if self.dfc is not None:
-            egrid = np.arange(
-                0, self.dfc.nedos * self.dfc.deltae, self.dfc.deltae
-            )
+            egrid = np.linspace(
+                0, self.dfc.nedos * self.dfc.deltae, self.dfc.nedos,endpoint=False
+                                        )
             alpha_dark = np.zeros_like(egrid, dtype=np.complex128)
             alpha_light_dict = {
                 key: np.zeros_like(egrid, dtype=np.complex128)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 long_description = pathlib.Path("README.md").read_text()
 setup(
     name="pytaser",
-    version="2.1.2",
+    version="2.1.3",
     description="TAS prediction tool",
     url="https://pytaser.readthedocs.io/en/latest/",
     author="Savyasanchi Aggarwal",


### PR DESCRIPTION
Changed np.arange to np.linspace for the generation of egrid inside occ_dependent_alpha and generate_tas from generator.py. The np.arange can create e_grid arrays with sizes different from NEDOS. 